### PR TITLE
Pin chalk dependency to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@types/cheerio": "^0.22.2",
-    "chalk": "^2.1.0",
+    "chalk": "2.1.0",
     "google-closure-compiler-js": "^20170626.0.0",
     "tmp": "^0.0.31",
     "tsickle": "^0.23.4",


### PR DESCRIPTION
Since chalk 2.2.0, chalk declares types in package.json, which
overrides the @types/chalk dependency and requires a default import.

See https://github.com/chalk/chalk/issues/215 for more context.