### PR TITLE
Add optional parameter for custom compiler options

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -166,7 +166,8 @@ export async function checkTemplate(
   additionalSources: Array<{
     src: string;
     path?: string;
-  }> = []
+  }> = [],
+  additionalClosureCompilerFlags?: Object
 ) {
   const polymerExterns = readFileSync(
     require.resolve(
@@ -244,6 +245,7 @@ export async function checkTemplate(
       src: sourceTest
     })
   };
+  Object.assign(closureCompilerFlags, additionalClosureCompilerFlags);
 
   const compiledResults = compile(closureCompilerFlags);
   for (const v of toProcess) {

--- a/test.ts
+++ b/test.ts
@@ -46,6 +46,22 @@ test("Multiple element working", async () => {
   );
 });
 
+test("ECMASCRIPT_NEXT features working", async () => {
+  await checkTemplate(
+    [
+      {
+        htmlSrcPath: "test/elms/async-elm.html",
+        jsSrcPath: "test/elms/async-elm.js",
+        jsModule: "foo.async_elm"
+      }
+    ],
+    [],
+    {
+      languageIn: "ECMASCRIPT_NEXT"
+    }
+  );
+});
+
 (async () => {
   for (const testCase of testsToRun) {
     await testRun(testCase);

--- a/test/elms/async-elm.html
+++ b/test/elms/async-elm.html
@@ -1,0 +1,10 @@
+<dom-module id="async-elm">
+    <template>
+        <style include="shared-styles">
+        </style>
+        <template is="dom-repeat" items="[[wow]]">
+            [[item.a]]
+        </template>
+    </template>
+    <script src="async-elm.js"></script>
+</dom-module>

--- a/test/elms/async-elm.js
+++ b/test/elms/async-elm.js
@@ -1,0 +1,18 @@
+goog.module("foo.async_elm");
+exports = Polymer({
+  is: "async-elm",
+  properties: {
+    /**
+     * @type {Array<!{a: string}>}
+     */
+    wow: []
+  },
+
+  observers: [
+    'onWowUpdated(wow)',
+  ],
+
+  async onWowUpdated(wow) {
+    await new Promise(resolve => resolve(wow));
+  },
+});


### PR DESCRIPTION
One use case is to support projects that use async/await and therefore
need to pass --language_in=ECMASCRIPT_NEXT to the compiler.